### PR TITLE
Bugfix do menu do burguer

### DIFF
--- a/styles/header.module.css
+++ b/styles/header.module.css
@@ -27,10 +27,8 @@
 {
     
     /*margin-left: calc(50% + (40% - 300px)) ;*/
-        
-    display: flex;    
-    text-align: center;    
-    justify-content: right;
+    display: none;
+    
 }
 
 .box_imenu
@@ -133,6 +131,12 @@
         display: flex;
 
     }       
+
+    .navbar_imenu {
+        display: flex;    
+        text-align: center;    
+        justify-content: right;
+    }
 }
 
 @media (max-width: 424px) {
@@ -158,8 +162,9 @@
     
     .navbar_imenu
     {
+        display: flex;    
+        text-align: center;    
         justify-content: center;
-        
     }
 
     .box_imenu


### PR DESCRIPTION
### Resumo
BUGFIX: A lista do menu do burguer fecha ao redimensionar a página. O bug foi resolvido no CSS.

### Como foi testado?
Abri a lista do menu do burguer e aumentei a largura da página no modo inspecionar.

### Informações úteis
O menu do burger é esse botão, e a lista linkada a ele.
![image](https://user-images.githubusercontent.com/84688945/168822890-0d9879b8-9439-424a-a4bb-22d26b317106.png)



